### PR TITLE
NewClientCallback called on the new goroutine

### DIFF
--- a/tcp_server.go
+++ b/tcp_server.go
@@ -22,6 +22,7 @@ type server struct {
 
 // Read client data from channel
 func (c *Client) listen() {
+        c.Server.onNewClientCallback(c)
 	reader := bufio.NewReader(c.conn)
 	for {
 		message, err := reader.ReadString('\n')
@@ -84,7 +85,6 @@ func (s *server) Listen() {
 			Server: s,
 		}
 		go client.listen()
-		s.onNewClientCallback(client)
 	}
 }
 

--- a/tcp_server.go
+++ b/tcp_server.go
@@ -22,7 +22,7 @@ type server struct {
 
 // Read client data from channel
 func (c *Client) listen() {
-        c.Server.onNewClientCallback(c)
+	c.Server.onNewClientCallback(c)
 	reader := bufio.NewReader(c.conn)
 	for {
 		message, err := reader.ReadString('\n')


### PR DESCRIPTION
NewClientCallback should be called on the new routine. in this way, it will never block new client connection. To test that try to add timer.Sleep in NewClientCallback callback function, this will prevent the server accepting new connection.