### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/tcp_server.go
+++ b/tcp_server.go
@@ -72,7 +72,7 @@ func (s *server) OnNewMessage(callback func(c *Client, message string)) {
 	s.onNewMessage = callback
 }
 
-// Start network server
+// Listen starts network server
 func (s *server) Listen() {
 	var listener net.Listener
 	var err error


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!