### PR TITLE
Add module support, check more errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
- - 1.7
+ - 1.11
 script:
  - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
- - 1.11
+ - 1.13
 script:
  - go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/firstrow/tcp_server
 
-go 1.7
+go 1.13
 
 require github.com/smartystreets/goconvey v1.6.4

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/firstrow/tcp_server
+
+go 1.7
+
+require github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/tcp_server.go
+++ b/tcp_server.go
@@ -39,13 +39,16 @@ func (c *Client) listen() {
 
 // Send text message to client
 func (c *Client) Send(message string) error {
-	_, err := c.conn.Write([]byte(message))
-	return err
+	return c.SendBytes([]byte(message))
 }
 
 // Send bytes to client
 func (c *Client) SendBytes(b []byte) error {
 	_, err := c.conn.Write(b)
+	if err != nil {
+		c.conn.Close()
+		c.Server.onClientConnectionClosed(c, err)
+	}
 	return err
 }
 

--- a/tcp_server_test.go
+++ b/tcp_server_test.go
@@ -39,7 +39,10 @@ func Test_accepting_new_client_callback(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to connect to test server")
 	}
-	conn.Write([]byte("Test message\n"))
+	_, err = conn.Write([]byte("Test message\n"))
+	if err != nil {
+		t.Fatal("Failed to send test message.")
+	}
 	conn.Close()
 
 	// Wait for server


### PR DESCRIPTION
Go 1.17 will ignore the GO111MODULE environment variable, so I have added module support and created more error checking.

I attempted to bump the Travis CI to use go 1.11, but the tests are still failing with the automated tests due to the conveyance package. They are working perfectly on my computer running go 1.16, though. I'm still investigating this.